### PR TITLE
fix: ensure x402-stellar-sdk dist is built before ui (#1)

### DIFF
--- a/packages/x402-stellar-sdk/package.json
+++ b/packages/x402-stellar-sdk/package.json
@@ -31,7 +31,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup",
+    "build": "tsup src/index.ts src/server/index.ts src/server/hono.ts src/server/next.ts src/client/index.ts --format esm --dts --out-dir dist",
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "npm run build"

--- a/ui/package.json
+++ b/ui/package.json
@@ -6,7 +6,9 @@
     "build": "next build",
     "dev": "next dev",
     "lint": "eslint .",
-    "start": "next start"
+    "start": "next start",
+    "prebuild": "npm run build -w packages/x402-stellar-sdk",
+    "predev": "npm run build -w packages/x402-stellar-sdk",
   },
   "dependencies": {
     "@allbridge/bridge-core-sdk": "^3.29.1",
@@ -67,6 +69,7 @@
     "recharts": "2.15.4",
     "sonner": "^1.7.4",
     "stellar-agent-kit": "^1.0.5",
+    "x402-stellar-sdk": "*",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.9",


### PR DESCRIPTION
Fixes #1

The SDK was never compiled because tsup had no entry points defined. The UI also never declared it as a dependency so npm did not link it locally.

Changes:
- packages/x402-stellar-sdk/package.json: add explicit tsup entry points
- ui/package.json: add x402-stellar-sdk workspace dep + prebuild/predev hooks

No source files changed.