### PR TITLE
fix: replace non-null env var assertions with explicit validation across SDK snippets and templates

### DIFF
--- a/packages/create-stellar-devkit-app/templates/x402-api/src/index.ts
+++ b/packages/create-stellar-devkit-app/templates/x402-api/src/index.ts
@@ -7,7 +7,8 @@ import { x402 } from "x402-stellar-sdk/server";
 const app = express();
 app.use(express.json());
 
-const destination = process.env.X402_DESTINATION || "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA2X";
+const destination = process.env.X402_DESTINATION;
+if (!destination) throw new Error("X402_DESTINATION is required. Set it in .env or .env.local.");
 const network = (process.env.NETWORK === "mainnet" ? "mainnet" : "testnet") as "mainnet" | "testnet";
 
 app.use(

--- a/packages/stellar-devkit-mcp/src/index.ts
+++ b/packages/stellar-devkit-mcp/src/index.ts
@@ -115,8 +115,11 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
   if (name === "get_sdk_snippet") {
     const op = (args?.operation as string)?.toLowerCase() || "";
     const snippets: Record<string, string> = {
+     // this is a code snippet the MCP serves to developers. They will copy-paste it directly into their projects If it shows process.env.SECRET_KEY!, they inherit the bad pattern their app will crash with a **cryptic** Stellar SDK error instead of a clear message when the env var is missing
       swap: `import { StellarAgentKit, MAINNET_ASSETS } from "stellar-agent-kit";
-const agent = new StellarAgentKit(process.env.SECRET_KEY!, "mainnet");
+const secretKey = process.env.SECRET_KEY;
+if (!secretKey) throw new Error("SECRET_KEY is required.");
+const agent = new StellarAgentKit(secretKey, "mainnet");
 await agent.initialize();
 const quote = await agent.dexGetQuote(
   { contractId: MAINNET_ASSETS.XLM.contractId },
@@ -132,8 +135,11 @@ const quote = await agent.dexGetQuote(
   { contractId: MAINNET_ASSETS.USDC.contractId },
   amount
 );`,
+// same reason as "swap" above it's a copy-paste snippet
       "x402-server": `import { x402 } from "x402-stellar-sdk/server";
-const options = { price: "1", assetCode: "XLM", network: "testnet" as const, destination: process.env.X402_DESTINATION! };
+const destination = process.env.X402_DESTINATION;
+if (!destination) throw new Error("X402_DESTINATION is required.");
+const options = { price: "1", assetCode: "XLM", network: "testnet" as const, destination };
 app.use("/api/premium", x402(options));
 app.get("/api/premium", (req, res) => res.json({ data: "Premium content" }));`,
       "x402-client": `import { x402Fetch } from "x402-stellar-sdk/client";

--- a/sdk-fe/app/packages/stellar-agent-kit/page.tsx
+++ b/sdk-fe/app/packages/stellar-agent-kit/page.tsx
@@ -2,7 +2,9 @@
 
 const QUICK_START = `import { StellarAgentKit, MAINNET_ASSETS } from "stellar-agent-kit";
 
-const agent = new StellarAgentKit(process.env.SECRET_KEY!, "mainnet");
+const secretKey = process.env.SECRET_KEY;
+if (!secretKey) throw new Error("SECRET_KEY is required. Set it in .env or .env.local.");
+const agent = new StellarAgentKit(secretKey, "mainnet");
 await agent.initialize();
 
 const balances = await agent.getBalances();

--- a/sdk-fe/app/packages/x402-stellar-sdk/page.tsx
+++ b/sdk-fe/app/packages/x402-stellar-sdk/page.tsx
@@ -4,11 +4,13 @@ const SERVER_SNIPPET = `import express from "express";
 import { x402 } from "x402-stellar-sdk/server";
 
 const app = express();
+const destination = process.env.X402_DESTINATION;
+if (!destination) throw new Error("X402_DESTINATION is required. Set it in .env or .env.local.");
 const options = {
   price: "1",
   assetCode: "XLM",
   network: "testnet" as const,
-  destination: process.env.X402_DESTINATION!,
+  destination,
   memo: "premium-api",
 };
 app.use("/api/premium", x402(options));

--- a/sdk-fe/app/page.tsx
+++ b/sdk-fe/app/page.tsx
@@ -17,7 +17,9 @@ const NETWORKS = [
 const SNIPPETS = {
   "Agent Kit": `import { StellarAgentKit, MAINNET_ASSETS } from "stellar-agent-kit";
 
-const agent = new StellarAgentKit(process.env.SECRET_KEY!, "mainnet");
+const secretKey = process.env.SECRET_KEY;
+if (!secretKey) throw new Error("SECRET_KEY is required. Set it in .env or .env.local.");
+const agent = new StellarAgentKit(secretKey, "mainnet");
 await agent.initialize();
 
 const quote = await agent.dexGetQuote(
@@ -29,11 +31,13 @@ const result = await agent.dexSwap(quote);
 console.log(result.hash);`,
   "x402 Server": `import { x402 } from "x402-stellar-sdk/server";
 
+const destination = process.env.X402_DESTINATION;
+if (!destination) throw new Error("X402_DESTINATION is required. Set it in .env or .env.local.");
 const options = {
   price: "1",
   assetCode: "XLM",
   network: "testnet" as const,
-  destination: process.env.X402_DESTINATION!,
+  destination,
   memo: "premium",
 };
 app.use("/api/premium", x402(options));

--- a/ui/app/docs/page.tsx
+++ b/ui/app/docs/page.tsx
@@ -148,7 +148,9 @@ export default function DocsPage() {
             <CodeWindow
               code={`import { StellarAgentKit, MAINNET_ASSETS } from "stellar-agent-kit";
  
-const agent = new StellarAgentKit(process.env.SECRET_KEY!, "mainnet");
+const secretKey = process.env.SECRET_KEY;
+if (!secretKey) throw new Error("SECRET_KEY is required. Set it in .env or .env.local.");
+const agent = new StellarAgentKit(secretKey, "mainnet");
 await agent.initialize();
  
 // Get a swap quote (1 XLM → USDC, 7 decimals)
@@ -316,11 +318,13 @@ await agent.lendingBorrow({ ... });`}
 import { x402 } from "x402-stellar-sdk/server";
 
 const app = express();
+const destination = process.env.X402_DESTINATION;
+if (!destination) throw new Error("X402_DESTINATION is required. Set it in .env or .env.local.");
 const options = {
   price: "1",
   assetCode: "XLM",
   network: "testnet",
-  destination: process.env.X402_DESTINATION!,
+  destination,
   memo: "premium-api",
 };
 app.use("/api/premium", x402(options));

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -36,8 +36,9 @@ function FadeInSection({ children, className }: { children: ReactNode; className
 }
 
 const TRY_IT_SNIPPET = `import { StellarAgentKit, MAINNET_ASSETS } from "stellar-agent-kit";
-
-const agent = new StellarAgentKit(process.env.SECRET_KEY!, "mainnet");
+const secretKey = process.env.SECRET_KEY;
+if (!secretKey) throw new Error("SECRET_KEY is required. Set it in .env or .env.local.");
+const agent = new StellarAgentKit(secretKey, "mainnet");
 await agent.initialize();
 
 // Get a swap quote (1 XLM → USDC, 7 decimals)

--- a/ui/app/protocols/page.tsx
+++ b/ui/app/protocols/page.tsx
@@ -266,7 +266,9 @@ const CODE_BY_PROTOCOL: Record<string, { filename: string; code: string }> = {
     filename: "swap-soroswap.ts",
     code: `import { StellarAgentKit, MAINNET_ASSETS } from "stellar-agent-kit";
 
-const agent = new StellarAgentKit(process.env.SECRET_KEY!, "mainnet");
+const secretKey = process.env.SECRET_KEY;
+if (!secretKey) throw new Error("SECRET_KEY is required. Set it in .env or .env.local.");
+const agent = new StellarAgentKit(secretKey, "mainnet");
 await agent.initialize();
 
 const quote = await agent.dexGetQuote(
@@ -281,7 +283,9 @@ console.log("Swap tx hash:", result.hash);`,
     filename: "lending-blend.ts",
     code: `import { StellarAgentKit, MAINNET_ASSETS, BLEND_POOLS } from "stellar-agent-kit";
 
-const agent = new StellarAgentKit(process.env.SECRET_KEY!, "mainnet");
+const secretKey = process.env.SECRET_KEY;
+if (!secretKey) throw new Error("SECRET_KEY is required. Set it in .env or .env.local.");
+const agent = new StellarAgentKit(secretKey, "mainnet");
 await agent.initialize();
 
 // Supply
@@ -302,7 +306,9 @@ await agent.lendingBorrow({
     filename: "oracle-reflector.ts",
     code: `import { StellarAgentKit, MAINNET_ASSETS } from "stellar-agent-kit";
 
-const agent = new StellarAgentKit(process.env.SECRET_KEY!, "mainnet");
+const secretKey = process.env.SECRET_KEY;
+if (!secretKey) throw new Error("SECRET_KEY is required. Set it in .env or .env.local.");
+const agent = new StellarAgentKit(secretKey, "mainnet");
 await agent.initialize();
 
 const price = await agent.getPrice({ contractId: MAINNET_ASSETS.XLM.contractId });


### PR DESCRIPTION
# What I change

Several places in the codebase used TypeScript's non-null assertion (`!`) on
environment variables:

```ts
// Before — crashes with a cryptic error if SECRET_KEY is missing
const agent = new StellarAgentKit(process.env.SECRET_KEY!, "mainnet");

// Before — silently uses a dummy Stellar address that accepts payments but belongs to nobody
const destination = process.env.X402_DESTINATION || "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA2X";
```

When SECRET_KEY or X402_DESTINATION is missing, the app or MCP server would fail later with an opaque error from the Stellar SDK or downstream HTTP call (e.g. "invalid key format", "undefined is not a valid address") instead of a clear, actionable message pointing the developer to the missing env var.

## Changes
Runtime code

`packages/create-stellar-devkit-app/templates/x402-api/src/index.ts`

<img width="919" height="92" alt="image" src="https://github.com/user-attachments/assets/2a63c246-bcca-4712-b5c4-c7764152b528" />
 - Removed the silent fallback to a dummy/placeholder Stellar address (GAAA...). A   developer who scaffolds this template and forgets to set X402_DESTINATION would have had payments silently sent to a meaningless address. The server now fails fast on startup with:
 
 `X402_DESTINATION is required. Set it in .env or .env.local.`

### MCP snippets `(packages/stellar-devkit-mcp/src/index.ts)`

The MCP get_sdk_snippet tool returns code that developers copy-paste directly into their projects. If those snippets showed process.env.SECRET_KEY!, every developer who copied them would inherit the unsafe pattern. Both affected snippets now show the correct validated pattern:

- swap snippet: SECRET_KEY validated before passing to StellarAgentKit

<img width="1008" height="151" alt="image" src="https://github.com/user-attachments/assets/6485b5ec-1f42-45a3-840e-8ef338369d1a" />

- x402-server snippet: X402_DESTINATION validated before passing to x402()

<img width="838" height="99" alt="image" src="https://github.com/user-attachments/assets/b44b2d2c-80d8-4c4d-bbc7-d14f67baf372" />

### UI display snippets (ui/)
These are code examples shown to developers inside <CodeWindow> blocks on the landing page, docs page, and protocols page. They are not executed at runtime, but they are the primary way developers learn the pattern. All of them now show the safe read → check → throw pattern instead of !:

- `ui/app/page.tsx` — TRY_IT_SNIPPET hero section
- `ui/app/docs/page.tsx` — quick-start snippet (SECRET_KEY) and Express x402 snippet (X402_DESTINATION)
- `ui/app/protocols/page.tsx` — three protocol snippets (SoroSwap, Blend, Reflector), each using SECRET_KEY

### sdk-fe display snippets (sdk-fe/)
Same fix applied to the SDK documentation frontend:

- `sdk-fe/app/page.tsx `— "Agent Kit" and "x402 Server" tab snippets
- `sdk-fe/app/packages/stellar-agent-kit/page.tsx` — QUICK_START example
- `sdk-fe/app/packages/x402-stellar-sdk/page.tsx` — SERVER_SNIPPET example


## This Pattern i used consistently everywhere
```ts
// After — fails immediately with a clear, actionable message
const secretKey = process.env.SECRET_KEY;
if (!secretKey) throw new Error("SECRET_KEY is required. Set it in .env or .env.local.");
const agent = new StellarAgentKit(secretKey, "mainnet");

const destination = process.env.X402_DESTINATION;
if (!destination) throw new Error("X402_DESTINATION is required. Set it in .env or .env.local.");
const options = { price: "1", assetCode: "XLM", network: "testnet" as const, destination };
```

### As far my understanding of the codebase This things are no need to change

- `ui/app/api/x402/premium/route.t`s — already validates X402_DESTINATION and returns a structured 503 response with a clear message. No change needed.
- `packages/stellar-devkit-mcp/src/index.ts get_quote tool` — already validates SOROSWAP_API_KEY with a clear message before calling the SoroSwap API. No change needed.
- `scripts/test-sdk.mjs` — uses SECRET_KEY with an explicit fallback test key and is documented as optional. No change needed.

CLOSES #10 