### PR TITLE
Add OpenAI fallback for CLI agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 npm install stellar-agent-kit
 ```
 
-Optional, for DEX swaps: [SoroSwap API key](https://soroswap.com) (or use contract simulation). For the CLI agent: `GROQ_API_KEY` or pass `--api-key`.
+Optional, for DEX swaps: [SoroSwap API key](https://soroswap.com) (or use contract simulation). For the CLI agent: `GROQ_API_KEY`, or `OPENAI_API_KEY`, or pass `--api-key`.
 
 ### Develop from this repository
 
@@ -83,7 +83,7 @@ Run from the repo root after `npm run build` (or use the published `stellar-agen
 |--------|--------|
 | **Balance** | `node dist/index.js balance GABC... [--network=mainnet]` |
 | **Pay** | `node dist/index.js pay S... G... 10 [--network=mainnet]` |
-| **Agent** | `node dist/index.js agent` (set `GROQ_API_KEY` or `--api-key`) |
+| **Agent** | `node dist/index.js agent` (uses `GROQ_API_KEY`, then `OPENAI_API_KEY`, or `--api-key`) |
 
 Balance output: JSON array of `{ code, issuer, balance }`. Agent: interactive loop; try “What’s the balance of G…” or “Get a quote to swap 10 XLM to USDC”. Type `exit` to quit.
 
@@ -100,7 +100,7 @@ Balance output: JSON array of `{ code, issuer, balance }`. Agent: interactive lo
 ## Requirements
 
 - **Node.js** ≥ 18  
-- **Agent CLI:** `GROQ_API_KEY` (or `--api-key`)  
+- **Agent CLI:** `GROQ_API_KEY`, or `OPENAI_API_KEY`, or `--api-key`  
 - **DEX (optional):** SoroSwap API key for aggregator; otherwise simulation is used where supported  
 
 ---

--- a/src/demo/cliAgent.ts
+++ b/src/demo/cliAgent.ts
@@ -28,6 +28,13 @@ type AssistantMessage = {
 };
 type ChatMessage = AssistantMessage | { role: "tool"; tool_call_id: string; content: string } | { role: "user"; content: string };
 
+type AgentProviderConfig = {
+  apiKey: string;
+  baseURL: string;
+  model: string;
+  providerLabel: "Groq" | "OpenAI";
+};
+
 /** OpenAI-compatible tool definitions (JSON Schema for parameters). */
 function toOpenAITools(): ChatCompletionTool[] {
   return [
@@ -185,22 +192,18 @@ export function registerAgentCommand(program: Command): void {
   program
     .command("agent")
     .description("Chat with Stellar DeFi agent (balance, swap quotes)")
-    .option("--api-key <key>", "Groq API key (or set GROQ_API_KEY)")
+    .option("--api-key <key>", "LLM API key override (otherwise uses GROQ_API_KEY, then OPENAI_API_KEY)")
     .action(async (options: { apiKey?: string }) => {
-      const apiKey = options.apiKey ?? process.env.GROQ_API_KEY;
-      if (!apiKey) {
-        console.error("Error: Set GROQ_API_KEY or pass --api-key <key>");
-        process.exit(1);
-      }
+      const provider = resolveAgentProvider(options.apiKey);
 
       const { default: OpenAI } = await import("openai");
       const openai = new OpenAI({
-        apiKey,
-        baseURL: "https://api.groq.com/openai/v1",
+        apiKey: provider.apiKey,
+        baseURL: provider.baseURL,
       });
-      const model = "llama-3.1-8b-instant";
+      const model = provider.model;
 
-      console.log("Stellar DeFi Agent. Commands: check balance, get swap quotes. Type 'exit' to quit.\n");
+      console.log(`Stellar DeFi Agent (${provider.providerLabel}). Commands: check balance, get swap quotes. Type 'exit' to quit.\n`);
 
       const history: ChatMessage[] = [];
 
@@ -237,4 +240,41 @@ export function registerAgentCommand(program: Command): void {
         }
       }
     });
+}
+
+function resolveAgentProvider(apiKeyOverride?: string): AgentProviderConfig {
+  const override = apiKeyOverride?.trim();
+  if (override) {
+    return {
+      apiKey: override,
+      baseURL: "https://api.groq.com/openai/v1",
+      model: "llama-3.1-8b-instant",
+      providerLabel: "Groq",
+    };
+  }
+
+  const groqApiKey = process.env.GROQ_API_KEY?.trim();
+  if (groqApiKey) {
+    return {
+      apiKey: groqApiKey,
+      baseURL: "https://api.groq.com/openai/v1",
+      model: "llama-3.1-8b-instant",
+      providerLabel: "Groq",
+    };
+  }
+
+  const openaiApiKey = process.env.OPENAI_API_KEY?.trim();
+  if (openaiApiKey) {
+    return {
+      apiKey: openaiApiKey,
+      baseURL: "https://api.openai.com/v1",
+      model: "gpt-4o-mini",
+      providerLabel: "OpenAI",
+    };
+  }
+
+  console.error("Error: missing LLM credentials for `agent`.");
+  console.error("Set GROQ_API_KEY, or set OPENAI_API_KEY, or pass --api-key <key>.");
+  console.error("If you use --api-key without another flag, the CLI assumes a Groq-compatible key.");
+  process.exit(1);
 }

--- a/ui/app/docs/page.tsx
+++ b/ui/app/docs/page.tsx
@@ -443,7 +443,7 @@ npx create-stellar-devkit-app my-app --skip-install`}
               className="mb-4"
             />
             <h3 className="text-lg font-medium text-[#a78bfa] mt-6 mb-2">agent</h3>
-            <p className="text-zinc-400 text-sm mb-2">Interactive chat with tools: check_balance, swap_asset, get_swap_quote, create_trustline. Uses <code className="rounded bg-zinc-800/90 px-1.5 py-0.5 text-zinc-200 font-mono text-[0.9em]">GROQ_API_KEY</code> or <code className="rounded bg-zinc-800/90 px-1.5 py-0.5 text-zinc-200 font-mono text-[0.9em]">--api-key</code> (OpenAI-compatible).</p>
+            <p className="text-zinc-400 text-sm mb-2">Interactive chat with tools: check_balance, swap_asset, get_swap_quote, create_trustline. Uses <code className="rounded bg-zinc-800/90 px-1.5 py-0.5 text-zinc-200 font-mono text-[0.9em]">GROQ_API_KEY</code>, falls back to <code className="rounded bg-zinc-800/90 px-1.5 py-0.5 text-zinc-200 font-mono text-[0.9em]">OPENAI_API_KEY</code>, or accepts <code className="rounded bg-zinc-800/90 px-1.5 py-0.5 text-zinc-200 font-mono text-[0.9em]">--api-key</code>.</p>
             <CodeWindow
               code={`node dist/index.js agent [--api-key <key>]
 # At prompt: "What's the balance of G...?" or "Get a quote to swap 10 XLM to USDC"`}
@@ -503,8 +503,8 @@ npx create-stellar-devkit-app my-app --skip-install`}
                   <tr className="border-b border-zinc-800"><td className="p-3 font-mono">DODO_PAYMENTS_PRODUCT_BUILDER</td><td className="p-3">ui (Pricing)</td><td className="p-3">Dodo product ID for Builder plan (create one-time product in dashboard).</td></tr>
                   <tr className="border-b border-zinc-800"><td className="p-3 font-mono">DODO_PAYMENTS_PRODUCT_PRO</td><td className="p-3">ui (Pricing)</td><td className="p-3">Dodo product ID for Pro plan (create one-time product in dashboard).</td></tr>
                   <tr className="border-b border-zinc-800"><td className="p-3 font-mono">DODO_PAYMENTS_ENVIRONMENT</td><td className="p-3">ui (Pricing)</td><td className="p-3">Optional: <code className="rounded bg-zinc-800/90 px-1.5 py-0.5 text-zinc-200 font-mono text-[0.9em]">test_mode</code> or <code className="rounded bg-zinc-800/90 px-1.5 py-0.5 text-zinc-200 font-mono text-[0.9em]">live_mode</code>. Default: test_mode.</td></tr>
-                  <tr className="border-b border-zinc-800"><td className="p-3 font-mono">GROQ_API_KEY</td><td className="p-3">CLI agent, Docs assistant</td><td className="p-3">Or OPENAI_API_KEY for docs assistant; CLI can use --api-key.</td></tr>
-                  <tr><td className="p-3 font-mono">OPENAI_API_KEY</td><td className="p-3">Docs assistant</td><td className="p-3">Optional; used if GROQ_API_KEY is not set.</td></tr>
+                  <tr className="border-b border-zinc-800"><td className="p-3 font-mono">GROQ_API_KEY</td><td className="p-3">CLI agent, Docs assistant</td><td className="p-3">Preferred for the CLI agent and docs assistant. CLI also accepts --api-key.</td></tr>
+                  <tr><td className="p-3 font-mono">OPENAI_API_KEY</td><td className="p-3">CLI agent, Docs assistant</td><td className="p-3">Optional fallback when GROQ_API_KEY is not set.</td></tr>
                 </tbody>
               </table>
             </div>


### PR DESCRIPTION
## Summary

This PR improves the CLI agent startup flow by removing the hard dependency on `GROQ_API_KEY`.

Changes included:
- add `OPENAI_API_KEY` fallback for the CLI agent
- keep `GROQ_API_KEY` as the preferred provider when available
- improve startup error messages when no LLM credentials are configured
- show which provider the CLI agent is using at startup
- update README and in-app docs to reflect the new behavior

## Why

Previously, the CLI agent required `GROQ_API_KEY` and exited immediately if it was missing, even when an OpenAI-compatible fallback would have been reasonable. This created unnecessary friction and unclear setup failures.

With this change:
- users can run the agent with `GROQ_API_KEY`
- or fall back to `OPENAI_API_KEY`
- or still pass `--api-key` explicitly

## Files changed

- `src/demo/cliAgent.ts`
- `README.md`
- `ui/app/docs/page.tsx`

## Notes

I was not able to fully run build/typecheck verification in the current environment because:
- `tsc` was not available in the sandboxed shell
- additional `npm exec` verification hit network/sandbox restrictions



The failing checks appear to be Vercel authorization issues rather than code or merge conflicts.

Both failed checks show:
- `Authorization required to deploy`

This PR comes from a fork, so I likely do not have permission to trigger preview deployments for the linked Vercel projects. Happy to update anything else if needed, but this seems to require maintainer-side authorization or a rerun from the main repository context.
