### PR TITLE
Fix: Persist AgentChat history across page refreshes

### DIFF
--- a/ui/components/agent-chat.tsx
+++ b/ui/components/agent-chat.tsx
@@ -20,10 +20,46 @@ type AgentQuote = {
   rawData?: unknown
 }
 
+// ─── localStorage persistence ────────────────────────────────────────────────
+const CHAT_STORAGE_KEY = "agent_chat_history"
+const CHAT_TTL_MS = 24 * 60 * 60 * 1000 // 24 h — matches issue acceptance criteria
+
+type PersistedChat = {
+  messages: Message[]
+  lastActivityAt: number
+}
+
+function loadPersistedMessages(): Message[] {
+  if (typeof window === "undefined") return []
+  try {
+    const raw = localStorage.getItem(CHAT_STORAGE_KEY)
+    if (!raw) return []
+    const { messages, lastActivityAt } = JSON.parse(raw) as PersistedChat
+    if (Date.now() - lastActivityAt > CHAT_TTL_MS) {
+      localStorage.removeItem(CHAT_STORAGE_KEY)
+      return []
+    }
+    return Array.isArray(messages) ? messages : []
+  } catch {
+    return []
+  }
+}
+
+function persistMessages(messages: Message[]) {
+  if (typeof window === "undefined") return
+  try {
+    const payload: PersistedChat = { messages, lastActivityAt: Date.now() }
+    localStorage.setItem(CHAT_STORAGE_KEY, JSON.stringify(payload))
+  } catch {
+    // localStorage quota exceeded or unavailable — fail silently
+  }
+}
+// ─────────────────────────────────────────────────────────────────────────────
+
 export function AgentChat() {
   const { account } = useAccount()
   const { buildSwap, submitSwap, isLoading: swapLoading } = useSoroSwap()
-  const [messages, setMessages] = useState<Message[]>([])
+  const [messages, setMessages] = useState<Message[]>(() => loadPersistedMessages())
   const [input, setInput] = useState("")
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -31,6 +67,11 @@ export function AgentChat() {
   const [pendingQuote, setPendingQuote] = useState<AgentQuote | null>(null)
   const bottomRef = useRef<HTMLDivElement>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  // Persist whenever messages change
+  useEffect(() => {
+    persistMessages(messages)
+  }, [messages])
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" })
@@ -109,6 +150,11 @@ export function AgentChat() {
       const msg = err instanceof Error ? err.message : String(err)
       toast.error("Swap failed", { description: msg })
     }
+  }
+
+  const clearHistory = () => {
+    setMessages([])
+    localStorage.removeItem(CHAT_STORAGE_KEY)
   }
 
   const hasMessages = messages.length > 0
@@ -199,6 +245,16 @@ export function AgentChat() {
                 <span className="text-white font-medium">DeFi Agent</span>
                 <ChevronDown className="w-4 h-4 text-zinc-500" />
               </button>
+              {hasMessages && (
+                <button
+                  type="button"
+                  onClick={clearHistory}
+                  className="px-2 py-1.5 rounded-lg hover:bg-zinc-800 hover:text-zinc-300 transition-colors text-xs text-zinc-500"
+                  title="Clear chat history"
+                >
+                  Clear history
+                </button>
+              )}
             </div>
             <LiquidMetalButton
               type="submit"


### PR DESCRIPTION
## Fix: Persist AgentChat history across page refreshes

This PR fixes issue #2  

### Root Cause

The bug report pointed to a module-level Map in route.ts but that does not
exist. The route is stateless by design - the client sends full message
history on every request. The real gap was AgentChat storing messages in
useState, which is lost on every page refresh.

### What changed

Only AgentChat.tsx was touched. No backend changes, no new dependencies.

Added loadPersistedMessages() and persistMessages() helpers around
localStorage with a 24h TTL. History loads on mount via a lazy useState
initializer. A clear history button was added for manual wipe.

### Acceptance criteria

1. History survives next dev restart

Code:
const [messages, setMessages] = useState<Message[]>(() => loadPersistedMessages())

localStorage is browser-side and completely independent of the server.
Restarting the dev server has no effect on stored history. Met.

2. Two separate Node processes serve the same history for the same session_id

Code:
const chatMessages = [...messages, userMessage].map((m) => ({
  role: m.role,
  content: m.content,
}))

Met by architecture, but with a gap to call out. There is no session_id
concept anywhere in this codebase - not in AgentChat.tsx and not in
route.ts. The route is stateless and the client already sends the full
message history on every request, so whichever process handles the request
it always receives the same data from the client. localStorage is what
keeps that client-side history consistent across page refreshes.

The session_id criterion as written does not apply to this architecture.
If cross-device or cross-browser history sync is needed in future, that
is when a session_id and a backend store like Supabase would make sense.

3. History is cleaned up after a configurable TTL

Code:
const CHAT_TTL_MS = 24 * 60 * 60 * 1000 // 24h default

TTL is a named constant at the top of the file, easy to find and change
in one place. The cleanup logic evicts stale data on load:

if (Date.now() - lastActivityAt > CHAT_TTL_MS) {
  localStorage.removeItem(CHAT_STORAGE_KEY)
  return []
}

Gap: this is not env-configurable without a code change. If the maintainer
wants true runtime configurability without touching code, this one line
change is all it needs:

const CHAT_TTL_MS = Number(process.env.NEXT_PUBLIC_CHAT_TTL_MS) || 24 * 60 * 60 * 1000

Happy to update this if needed.

### Why localStorage not Supabase

The client already owns the full history so localStorage keeps the existing
architecture intact. The codebase already uses it for PROJECT_STORAGE_KEY
and stellar_devkit_plan_order. No auth is needed and wallet data stays
on the client. Supabase is the right call if user accounts or cross-device
sync are added later, not now.

### Files changed

ui/app/components/AgentChat.tsx

