### PR TITLE
fix: rename UI package name from "orbit" to "stellar-agent-kit-ui"

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "orbit",
+  "name": "stellar-agent-kit-ui",
   "version": "1.0.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary

Fixes #11

The `ui/package.json` had `"name": "orbit"` while the README and CONTRIBUTING docs refer to the app as the "reference UI" and part of `stellar-agent-kit`. This naming mismatch confuses contributors when looking at workspace scripts and package references.

## Change

### `ui/package.json`
Renamed `"name"` from `"orbit"` to `"stellar-agent-kit-ui"` to align with the repo branding and make the workspace package identity immediately clear to contributors.

```diff
- "name": "orbit",
+ "name": "stellar-agent-kit-ui",
```