### PR TITLE
feat(env): add Zod-based environment variable validation at startup

### DIFF
--- a/packages/stellar-agent-kit/src/__tests__/env.test.ts
+++ b/packages/stellar-agent-kit/src/__tests__/env.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "vitest";
+import {
+  validateStellarEnv,
+  validateX402Env,
+  validateMcpEnv,
+  StellarEnvSchema,
+  X402EnvSchema,
+} from "../config/env.js";
+
+const VALID_SECRET =
+  "SCZWJ5X5NPL6I6ET6QRTQZLXH6CCPIYKIACHGUPMAZHMFVYUL234JVXC";
+const VALID_PUBLIC =
+  "GAMVCXSK654EKLOWMPJZCGUXKEW7X5RF74YZ6GBZV2FUJGJT6XG7HMHI";
+
+describe("StellarEnvSchema", () => {
+  it("accepts a valid Stellar secret key", () => {
+    const result = StellarEnvSchema.safeParse({
+      SECRET_KEY: VALID_SECRET,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects missing SECRET_KEY", () => {
+    const result = StellarEnvSchema.safeParse({});
+    expect(result.success).toBe(false);
+    expect(result.error?.errors[0].message).toContain("required");
+  });
+
+  it("rejects a public key used as SECRET_KEY", () => {
+    const result = StellarEnvSchema.safeParse({
+      SECRET_KEY: VALID_PUBLIC,
+    });
+    expect(result.success).toBe(false);
+    expect(result.error?.errors[0].message).toContain(
+      "valid Stellar secret key"
+    );
+  });
+
+  it("rejects an empty string SECRET_KEY", () => {
+    const result = StellarEnvSchema.safeParse({ SECRET_KEY: "" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a plaintext password as SECRET_KEY", () => {
+    const result = StellarEnvSchema.safeParse({
+      SECRET_KEY: "mypassword123",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("X402EnvSchema", () => {
+  it("accepts a valid Stellar public key", () => {
+    const result = X402EnvSchema.safeParse({
+      X402_DESTINATION: VALID_PUBLIC,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects missing X402_DESTINATION", () => {
+    const result = X402EnvSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a secret key used as X402_DESTINATION", () => {
+    const result = X402EnvSchema.safeParse({
+      X402_DESTINATION: VALID_SECRET,
+    });
+    expect(result.success).toBe(false);
+    expect(result.error?.errors[0].message).toContain(
+      "valid Stellar public key"
+    );
+  });
+});
+
+describe("validateStellarEnv", () => {
+  it("returns typed env when valid", () => {
+    const env = validateStellarEnv({ SECRET_KEY: VALID_SECRET });
+    expect(env.SECRET_KEY).toBe(VALID_SECRET);
+  });
+
+  it("throws descriptive error when SECRET_KEY is missing", () => {
+    expect(() => validateStellarEnv({})).toThrow(
+      "StellarAgentKit startup failed"
+    );
+  });
+
+  it("error message includes the field name and reason", () => {
+    expect(() => validateStellarEnv({ SECRET_KEY: "bad" })).toThrow(
+      "SECRET_KEY"
+    );
+  });
+});
+
+describe("validateX402Env", () => {
+  it("returns typed env when valid", () => {
+    const env = validateX402Env({ X402_DESTINATION: VALID_PUBLIC });
+    expect(env.X402_DESTINATION).toBe(VALID_PUBLIC);
+  });
+
+  it("throws descriptive error when X402_DESTINATION is missing", () => {
+    expect(() => validateX402Env({})).toThrow(
+      "x402-stellar-sdk startup failed"
+    );
+  });
+});
+
+describe("validateMcpEnv", () => {
+  it("returns success true with data when both vars present", () => {
+    const result = validateMcpEnv({
+      SECRET_KEY: VALID_SECRET,
+      SOROSWAP_API_KEY: "test-api-key-123",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.SECRET_KEY).toBe(VALID_SECRET);
+    }
+  });
+
+  it("returns success false when SECRET_KEY missing", () => {
+    const result = validateMcpEnv({
+      SOROSWAP_API_KEY: "test-api-key-123",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("SECRET_KEY");
+    }
+  });
+
+  it("returns success false when SOROSWAP_API_KEY missing", () => {
+    const result = validateMcpEnv({ SECRET_KEY: VALID_SECRET });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("SOROSWAP_API_KEY");
+    }
+  });
+
+  it("returns success false when both are missing", () => {
+    const result = validateMcpEnv({});
+    expect(result.success).toBe(false);
+  });
+
+  it("does not throw — returns error string instead", () => {
+    expect(() => validateMcpEnv({})).not.toThrow();
+  });
+});

--- a/packages/stellar-agent-kit/src/config/env.ts
+++ b/packages/stellar-agent-kit/src/config/env.ts
@@ -1,0 +1,101 @@
+import { z } from "zod";
+
+const stellarSecretKeyRegex = /^S[A-Z2-7]{55}$/;
+const stellarPublicKeyRegex = /^G[A-Z2-7]{55}$/;
+
+export const StellarEnvSchema = z.object({
+  SECRET_KEY: z
+    .string({ required_error: "SECRET_KEY is required" })
+    .regex(
+      stellarSecretKeyRegex,
+      "SECRET_KEY must be a valid Stellar secret key starting with S (56 chars)"
+    ),
+});
+
+export const X402EnvSchema = z.object({
+  X402_DESTINATION: z
+    .string({ required_error: "X402_DESTINATION is required" })
+    .regex(
+      stellarPublicKeyRegex,
+      "X402_DESTINATION must be a valid Stellar public key starting with G (56 chars)"
+    ),
+});
+
+export const SoroSwapEnvSchema = z.object({
+  SOROSWAP_API_KEY: z
+    .string({ required_error: "SOROSWAP_API_KEY is required" })
+    .min(1, "SOROSWAP_API_KEY cannot be empty"),
+});
+
+export const McpEnvSchema = z.object({
+  SECRET_KEY: z
+    .string({ required_error: "SECRET_KEY is required for execute_swap" })
+    .regex(
+      stellarSecretKeyRegex,
+      "SECRET_KEY must be a valid Stellar secret key starting with S (56 chars)"
+    ),
+  SOROSWAP_API_KEY: z
+    .string({ required_error: "SOROSWAP_API_KEY is required" })
+    .min(1, "SOROSWAP_API_KEY cannot be empty"),
+});
+
+export type StellarEnv = z.infer<typeof StellarEnvSchema>;
+export type X402Env = z.infer<typeof X402EnvSchema>;
+export type SoroSwapEnv = z.infer<typeof SoroSwapEnvSchema>;
+export type McpEnv = z.infer<typeof McpEnvSchema>;
+
+/**
+ * Validate required env vars for StellarAgentKit.
+ * Throws a descriptive ZodError if any are missing or malformed.
+ * Call once at startup before constructing StellarAgentKit.
+ */
+export function validateStellarEnv(
+  env: NodeJS.ProcessEnv = process.env
+): StellarEnv {
+  const result = StellarEnvSchema.safeParse(env);
+  if (!result.success) {
+    const messages = result.error.errors
+      .map((e) => `  - ${e.path.join(".")}: ${e.message}`)
+      .join("\n");
+    throw new Error(
+      `StellarAgentKit startup failed — missing or invalid env vars:\n${messages}`
+    );
+  }
+  return result.data;
+}
+
+/**
+ * Validate required env vars for x402-stellar-sdk server middleware.
+ */
+export function validateX402Env(
+  env: NodeJS.ProcessEnv = process.env
+): X402Env {
+  const result = X402EnvSchema.safeParse(env);
+  if (!result.success) {
+    const messages = result.error.errors
+      .map((e) => `  - ${e.path.join(".")}: ${e.message}`)
+      .join("\n");
+    throw new Error(
+      `x402-stellar-sdk startup failed — missing or invalid env vars:\n${messages}`
+    );
+  }
+  return result.data;
+}
+
+/**
+ * Validate env vars for MCP execute_swap tool.
+ * Returns a typed result instead of throwing — 
+ * MCP tools return error messages rather than crashing.
+ */
+export function validateMcpEnv(
+  env: NodeJS.ProcessEnv = process.env
+): { success: true; data: McpEnv } | { success: false; error: string } {
+  const result = McpEnvSchema.safeParse(env);
+  if (!result.success) {
+    const messages = result.error.errors
+      .map((e) => `${e.path.join(".")}: ${e.message}`)
+      .join("; ");
+    return { success: false, error: messages };
+  }
+  return { success: true, data: result.data };
+}

--- a/packages/stellar-agent-kit/src/index.ts
+++ b/packages/stellar-agent-kit/src/index.ts
@@ -32,3 +32,12 @@ export {
   type LendingResult,
 } from "./lending/index.js";
 export { FXDAO_MAINNET, ALLBRIDGE_CORE_STELLAR_DOCS } from "./config/protocols.js";
+export {
+  validateStellarEnv,
+  validateX402Env,
+  validateMcpEnv,
+  StellarEnvSchema,
+  X402EnvSchema,
+  SoroSwapEnvSchema,
+  McpEnvSchema,
+} from "./config/env.js";


### PR DESCRIPTION
## Summary
Resolves #4 — adds structured env var validation so missing
or malformed variables produce clear startup errors instead
of cryptic runtime failures deep inside the Stellar SDK.

## Problem
When SECRET_KEY, X402_DESTINATION, or SOROSWAP_API_KEY are
missing or malformed, the SDK currently crashes with internal
Stellar SDK errors like `Invalid secret key.` with no
indication of which env var caused the problem or how to fix
it. Issue #4 identified this as a significant DX problem.

The MCP server code itself contains comments flagging this:
*"their app will crash with a cryptic Stellar SDK error
instead of a clear message when the env var is missing"*

## Changes

### New: `packages/stellar-agent-kit/src/config/env.ts`
Four Zod schemas with regex enforcement:
- `StellarEnvSchema` — SECRET_KEY must match `/^S[A-Z2-7]{55}$/`
- `X402EnvSchema` — X402_DESTINATION must match `/^G[A-Z2-7]{55}$/`
- `SoroSwapEnvSchema` — SOROSWAP_API_KEY must be non-empty
- `McpEnvSchema` — SECRET_KEY + SOROSWAP_API_KEY combined

Three validators:
- `validateStellarEnv()` — throws on startup with field-level errors
- `validateX402Env()` — throws on startup with field-level errors
- `validateMcpEnv()` — returns result object (MCP tools must not
  crash — they return structured error messages instead)

### New: `packages/stellar-agent-kit/src/__tests__/env.test.ts`
18 tests covering:
- Valid secret and public key acceptance
- Missing required vars
- Wrong key type (public key used as secret key and vice versa)
- Empty string rejection
- Plaintext password rejection
- MCP validator non-throwing contract

### Updated: `packages/stellar-agent-kit/src/index.ts`
All schemas and validators exported from the public package API
so developers can call `validateStellarEnv()` before constructing
`StellarAgentKit`.

## Before vs After
```
// Before — cryptic crash inside Stellar SDK:
const agent = new StellarAgentKit(process.env.SECRET_KEY!, "mainnet")
// → TypeError: Invalid secret key.

// After — clear startup error:
validateStellarEnv(); // throws immediately:
// StellarAgentKit startup failed — missing or invalid env vars:
//   - SECRET_KEY: SECRET_KEY must be a valid Stellar secret key
//     starting with S (56 chars)
```

## Verification
```
npx tsc --noEmit → 0 errors in new files
npm test → 36 passed (18 new + 18 existing), 0 failed
```

Closes #4