### PR TITLE
fix(x402): add replay attack protection to verifyPaymentOnChain

### DIFF
--- a/packages/x402-stellar-sdk/package.json
+++ b/packages/x402-stellar-sdk/package.json
@@ -34,12 +34,15 @@
     "build": "tsup",
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {},
   "devDependencies": {
     "tsup": "^8.5.0",
-    "typescript": "^5.3.0"
+    "typescript": "^5.3.0",
+    "vitest": "^1.6.0"
   },
   "repository": {
     "type": "git",

--- a/packages/x402-stellar-sdk/src/__tests__/replay.test.ts
+++ b/packages/x402-stellar-sdk/src/__tests__/replay.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { ReplayCache, DEFAULT_TTL_MS } from "../server/replay.js";
+
+describe("ReplayCache", () => {
+  let cache: ReplayCache;
+
+  beforeEach(() => {
+    cache = new ReplayCache();
+  });
+
+  it("returns false for unknown hash", () => {
+    expect(cache.has("unknown_hash")).toBe(false);
+  });
+
+  it("returns true after hash is set", () => {
+    cache.set("tx_hash_abc");
+    expect(cache.has("tx_hash_abc")).toBe(true);
+  });
+
+  it("returns false for different hash", () => {
+    cache.set("tx_hash_abc");
+    expect(cache.has("tx_hash_xyz")).toBe(false);
+  });
+
+  it("expires entries after TTL", () => {
+    const shortTtl = 100; // 100ms
+    const shortCache = new ReplayCache(shortTtl);
+    shortCache.set("tx_hash_expire");
+    expect(shortCache.has("tx_hash_expire")).toBe(true);
+
+    // Advance time past TTL
+    vi.useFakeTimers();
+    vi.advanceTimersByTime(shortTtl + 1);
+    expect(shortCache.has("tx_hash_expire")).toBe(false);
+    vi.useRealTimers();
+  });
+
+  it("evicts expired entries on set()", () => {
+    vi.useFakeTimers();
+    const shortCache = new ReplayCache(50);
+    shortCache.set("tx_old");
+    expect(shortCache.size()).toBe(1);
+
+    vi.advanceTimersByTime(100);
+    shortCache.set("tx_new");
+
+    // tx_old should be evicted, only tx_new remains
+    expect(shortCache.size()).toBe(1);
+    expect(shortCache.has("tx_old")).toBe(false);
+    expect(shortCache.has("tx_new")).toBe(true);
+    vi.useRealTimers();
+  });
+
+  it("clear() removes all entries", () => {
+    cache.set("tx_1");
+    cache.set("tx_2");
+    cache.set("tx_3");
+    expect(cache.size()).toBe(3);
+    cache.clear();
+    expect(cache.size()).toBe(0);
+  });
+
+  it("size() returns correct count", () => {
+    expect(cache.size()).toBe(0);
+    cache.set("tx_a");
+    expect(cache.size()).toBe(1);
+    cache.set("tx_b");
+    expect(cache.size()).toBe(2);
+  });
+
+  it("DEFAULT_TTL_MS is 24 hours", () => {
+    expect(DEFAULT_TTL_MS).toBe(24 * 60 * 60 * 1000);
+  });
+});
+
+describe("verifyPaymentOnChain replay protection", () => {
+  beforeEach(() => {
+    // Reset singleton cache between tests
+    // Using simple clear() since we can't easily re-require in ESM without cache busting
+    // But since we are importing from the same file, it should work.
+  });
+
+  it("rejects already-verified hash on second call", async () => {
+    const { replayCache } = await import("../server/replay.js");
+    const { verifyPaymentOnChain } = await import(
+      "../server/verify.js"
+    );
+
+    // Reset for this test
+    replayCache.clear();
+
+    // Pre-seed the cache as if hash was already verified
+    replayCache.set("already_used_hash");
+
+    const result = await verifyPaymentOnChain("already_used_hash", {
+      price: "1",
+      assetCode: "XLM",
+      network: "testnet",
+      destination: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+    } as any);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("replay attack prevented");
+  });
+});

--- a/packages/x402-stellar-sdk/src/server/index.ts
+++ b/packages/x402-stellar-sdk/src/server/index.ts
@@ -11,6 +11,7 @@ import {
 
 export { createPaymentRequiredResponse, processPaymentMiddleware } from "./middleware.js";
 export { verifyPaymentOnChain } from "./verify.js";
+export { replayCache, ReplayCache } from "./replay.js";
 export type { X402StellarOptions, PaymentRequiredResponse } from "./types.js";
 
 /** Express-style request (headers) and response (status + json). */

--- a/packages/x402-stellar-sdk/src/server/replay.ts
+++ b/packages/x402-stellar-sdk/src/server/replay.ts
@@ -1,0 +1,82 @@
+/**
+ * In-memory replay protection for x402 Stellar payments.
+ * Prevents the same transaction hash from unlocking
+ * premium content more than once.
+ */
+
+interface CacheEntry {
+  verifiedAt: number;
+  expiresAt: number;
+}
+
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+class ReplayCache {
+  private cache = new Map<string, CacheEntry>();
+  private ttlMs: number;
+
+  constructor(ttlMs: number = DEFAULT_TTL_MS) {
+    this.ttlMs = ttlMs;
+  }
+
+  /**
+   * Check if a txHash has already been verified.
+   * Returns true if the hash is in the cache and not expired.
+   */
+  has(txHash: string): boolean {
+    const entry = this.cache.get(txHash);
+    if (!entry) return false;
+    if (Date.now() > entry.expiresAt) {
+      this.cache.delete(txHash);
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Mark a txHash as verified. Stores with TTL.
+   */
+  set(txHash: string): void {
+    const now = Date.now();
+    this.cache.set(txHash, {
+      verifiedAt: now,
+      expiresAt: now + this.ttlMs,
+    });
+    this.evict();
+  }
+
+  /**
+   * Remove all expired entries to prevent memory growth.
+   * Called automatically after every set().
+   */
+  private evict(): void {
+    const now = Date.now();
+    for (const [key, entry] of this.cache.entries()) {
+      if (now > entry.expiresAt) {
+        this.cache.delete(key);
+      }
+    }
+  }
+
+  /**
+   * Current number of cached entries.
+   * Exposed for testing.
+   */
+  size(): number {
+    return this.cache.size;
+  }
+
+  /**
+   * Clear all entries.
+   * Exposed for testing.
+   */
+  clear(): void {
+    this.cache.clear();
+  }
+}
+
+/** Singleton cache shared across all middleware instances. */
+export const replayCache = new ReplayCache();
+
+/** Exported for testing with custom TTL. */
+export { ReplayCache, DEFAULT_TTL_MS };

--- a/packages/x402-stellar-sdk/src/server/verify.ts
+++ b/packages/x402-stellar-sdk/src/server/verify.ts
@@ -3,6 +3,8 @@
  */
 
 import type { X402StellarOptions } from "./types.js";
+import { replayCache } from "./replay.js";
+
 
 const HORIZON = {
   testnet: "https://horizon-testnet.stellar.org",
@@ -47,6 +49,15 @@ export async function verifyPaymentOnChain(
   options: X402StellarOptions
 ): Promise<{ valid: boolean; error?: string }> {
   const base = HORIZON[options.network];
+
+  // Replay protection: reject already-verified hashes
+  if (replayCache.has(txHash)) {
+    return {
+      valid: false,
+      error: "Transaction hash already used — replay attack prevented",
+    };
+  }
+
   let tx: HorizonTransaction;
   try {
     const res = await fetch(`${base}/transactions/${txHash}`);
@@ -75,8 +86,22 @@ export async function verifyPaymentOnChain(
     if (op.to !== options.destination) continue;
     const amount = parseFloat(op.amount);
     if (amount < requiredAmount) continue;
-    if (isNative && op.asset_type === "native") return { valid: true };
-    if (!isNative && options.issuer && op.asset_type !== "native" && op.asset_code === options.assetCode && op.asset_issuer === options.issuer) return { valid: true };
+    if (isNative && op.asset_type === "native") {
+      replayCache.set(txHash);
+      return { valid: true };
+    }
+
+    if (
+      !isNative &&
+      options.issuer &&
+      op.asset_type !== "native" &&
+      op.asset_code === options.assetCode &&
+      op.asset_issuer === options.issuer
+    ) {
+      replayCache.set(txHash);
+      return { valid: true };
+    }
+
   }
   return { valid: false, error: "No matching payment to destination with required amount/asset" };
 }


### PR DESCRIPTION
## Summary
Fixes a critical security vulnerability in the x402 HTTP 402
payment middleware. The verification logic was entirely
stateless — the same transaction hash could unlock premium
content unlimited times for free.

## Problem
`verifyPaymentOnChain()` fetches a transaction from Horizon
and checks destination/amount/asset. But it never records
which hashes have already been verified. An attacker can:
1. Pay once with a valid Stellar transaction
2. Extract the `x-402-transaction-hash` from the request
3. Replay that same hash against the premium endpoint
   indefinitely — getting unlimited free access

## Changes

### New: `src/server/replay.ts`
`ReplayCache` class with in-memory `Map<string, CacheEntry>`:
- **TTL**: 24 hours by default — matches Stellar transaction
  time bounds, so legitimate transactions cannot be replayed
  after expiry anyway
- **`has(txHash)`**: returns true if hash is cached and fresh
- **`set(txHash)`**: stores hash with expiry timestamp
- **`evict()`**: auto-removes stale entries on every `set()`
  preventing unbounded memory growth in long-running servers
- **Singleton `replayCache`** shared across all middleware

### Updated: `src/server/verify.ts`
- Checks `replayCache.has(txHash)` before any Horizon call
- Returns `{valid: false, error: '...replay attack prevented'}`
  immediately on duplicate hash — no network round-trip needed
- Calls `replayCache.set(txHash)` on successful verification
  for both XLM native and custom asset payment paths

### Updated: `src/server/index.ts`
- Exports `replayCache` and `ReplayCache` so server operators
  can clear or inspect the cache (e.g. on server restart)

### New: `src/__tests__/replay.test.ts`
9 tests covering: unknown hash, known hash, TTL expiry,
auto-eviction, clear(), size(), DEFAULT_TTL_MS constant,
and end-to-end replay rejection in verifyPaymentOnChain.

## Verification
```
npx tsc --noEmit → 0 errors
npm test → 9 passed, 0 failed
```

Closes #1