### PR TITLE
feat(mcp): add get_account_balance tool

### DIFF
--- a/packages/stellar-devkit-mcp/src/index.ts
+++ b/packages/stellar-devkit-mcp/src/index.ts
@@ -119,6 +119,25 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         required: ["fromAsset", "toAsset", "amount"],
       },
     },
+    {
+      name: "get_account_balance",
+      description: "Get the balance of a Stellar account including XLM and all token balances. Takes a public key and returns a formatted balance summary.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          publicKey: {
+            type: "string",
+            description: "Stellar public key (G...)",
+          },
+          network: {
+            type: "string",
+            enum: ["mainnet", "testnet"],
+            description: "Network (mainnet default)",
+          },
+        },
+        required: ["publicKey"],
+      },
+    },
   ],
 }));
 
@@ -343,7 +362,66 @@ const res = await x402Fetch(url, undefined, {
       };
     }
   }
+  if (name === "get_account_balance") {
+    const publicKey = (args?.publicKey as string)?.trim();
+    const network = ((args?.network as string) || "mainnet").toLowerCase();
 
+    if (!publicKey) {
+      return { content: [{ type: "text", text: "Public key is required." }] };
+    }
+
+    // Basic validation for Stellar public key format
+    if (!publicKey.startsWith("G") || publicKey.length !== 56) {
+      return { content: [{ type: "text", text: "Invalid Stellar public key format. Public keys start with 'G' and are 56 characters long." }] };
+    }
+
+    try {
+      const config = getNetworkConfig(network as "mainnet" | "testnet");
+      const horizonUrl = config.horizonUrl;
+      
+      const response = await fetch(`${horizonUrl}/accounts/${publicKey}`);
+      
+      if (!response.ok) {
+        if (response.status === 404) {
+          return { content: [{ type: "text", text: `Account ${publicKey} not found on ${network}.` }] };
+        }
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+
+      const account = await response.json();
+      
+      // Format balances
+      const balances = account.balances.map((balance: any) => {
+        if (balance.asset_type === "native") {
+          return `XLM: ${parseFloat(balance.balance).toFixed(7)}`;
+        } else {
+          const assetCode = balance.asset_code || "Unknown";
+          const issuer = balance.asset_issuer ? ` (${balance.asset_issuer.substring(0, 8)}...)` : "";
+          return `${assetCode}${issuer}: ${parseFloat(balance.balance).toFixed(7)}`;
+        }
+      });
+
+      const text = [
+        `Account Balance Summary`,
+        `========================`,
+        `Public Key: ${publicKey}`,
+        `Network: ${network}`,
+        `Sequence: ${account.sequence}`,
+        ``,
+        `Balances:`,
+        ...balances.map((b: string) => `  ${b}`),
+        ``,
+        `Total Subentries: ${account.subentry_count}`,
+        `Last Modified: ${new Date(account.last_modified_time).toLocaleString()}`,
+      ].join("\n");
+
+      return { content: [{ type: "text", text }] };
+
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { content: [{ type: "text", text: `Failed to fetch account balance: ${message}` }] };
+    }
+  }
 
   throw new Error(`Unknown tool: ${name}`);
 });


### PR DESCRIPTION
Add new MCP tool to fetch and format Stellar account balances including XLM and all token balances. The tool:
- Takes a public key and optional network parameter
- Validates public key format
- Calls Horizon's /accounts/:id endpoint
- Returns formatted balance summary with all assets
- Handles errors gracefully (404, network issues, etc.)

This addresses the good first issue from CONTRIBUTING.md to enhance MCP functionality for Cursor/Claude users.