### PR TITLE
feat(lending): add lendingWithdraw and lendingRepay to Blend SDK

### DIFF
--- a/packages/stellar-agent-kit/src/__tests__/blend.test.ts
+++ b/packages/stellar-agent-kit/src/__tests__/blend.test.ts
@@ -1,9 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { lendingSupply, lendingBorrow, BLEND_POOLS_MAINNET, BLEND_POOLS } from "../lending/blend.js";
+import { lendingSupply, lendingBorrow, lendingWithdraw, lendingRepay, BLEND_POOLS_MAINNET, BLEND_POOLS } from "../lending/blend.js";
 import type { NetworkConfig } from "../config/networks.js";
 
 const mockNetworkConfig: NetworkConfig = {
-  network: "mainnet",
   horizonUrl: "https://horizon.stellar.org",
   sorobanRpcUrl: "https://soroban-rpc.stellar.org",
 };
@@ -98,6 +97,58 @@ describe("lendingBorrow", () => {
         poolId: BLEND_POOLS_MAINNET,
         assetContractId: USDC_CONTRACT,
         amount: "NaN",
+      })
+    ).rejects.toThrow();
+  });
+});
+
+describe("lendingWithdraw", () => {
+  it("is a function", () => {
+    expect(typeof lendingWithdraw).toBe("function");
+  });
+
+  it("throws when amount is not a valid BigInt string", async () => {
+    await expect(
+      lendingWithdraw(mockNetworkConfig, FAKE_SECRET, {
+        poolId: BLEND_POOLS_MAINNET,
+        assetContractId: USDC_CONTRACT,
+        amount: "not_a_number",
+      })
+    ).rejects.toThrow();
+  });
+
+  it("throws when poolId is empty", async () => {
+    await expect(
+      lendingWithdraw(mockNetworkConfig, FAKE_SECRET, {
+        poolId: "",
+        assetContractId: USDC_CONTRACT,
+        amount: "1000000",
+      })
+    ).rejects.toThrow();
+  });
+});
+
+describe("lendingRepay", () => {
+  it("is a function", () => {
+    expect(typeof lendingRepay).toBe("function");
+  });
+
+  it("throws when amount is not a valid BigInt string", async () => {
+    await expect(
+      lendingRepay(mockNetworkConfig, FAKE_SECRET, {
+        poolId: BLEND_POOLS_MAINNET,
+        assetContractId: USDC_CONTRACT,
+        amount: "not_a_number",
+      })
+    ).rejects.toThrow();
+  });
+
+  it("throws when poolId is empty", async () => {
+    await expect(
+      lendingRepay(mockNetworkConfig, FAKE_SECRET, {
+        poolId: "",
+        assetContractId: USDC_CONTRACT,
+        amount: "1000000",
       })
     ).rejects.toThrow();
   });

--- a/packages/stellar-agent-kit/src/agent.ts
+++ b/packages/stellar-agent-kit/src/agent.ts
@@ -7,7 +7,7 @@ import { Keypair, Asset, TransactionBuilder, Operation, Networks, Horizon } from
 import { getNetworkConfig, type NetworkConfig } from "./config/networks.js";
 import { createDexClient, type DexAsset, type QuoteResult, type SwapResult } from "./dex/index.js";
 import { createReflectorOracle, type OracleAsset, type PriceData } from "./oracle/index.js";
-import { lendingSupply as blendSupply, lendingBorrow as blendBorrow, type LendingSupplyArgs, type LendingBorrowArgs, type LendingResult } from "./lending/index.js";
+import { lendingSupply as blendSupply, lendingBorrow as blendBorrow, lendingWithdraw as blendWithdraw, lendingRepay as blendRepay, type LendingSupplyArgs, type LendingBorrowArgs, type LendingWithdrawArgs, type LendingRepayArgs, type LendingResult } from "./lending/index.js";
 
 /** This project is mainnet-only. */
 export type StellarNetwork = "mainnet" | "testnet";
@@ -245,5 +245,21 @@ export class StellarAgentKit {
   async lendingBorrow(args: LendingBorrowArgs): Promise<LendingResult> {
     this.ensureInitialized();
     return blendBorrow(this.config, this.keypair.secret(), args);
+  }
+
+  /**
+   * Withdraw collateral from a Blend pool.
+   */
+  async lendingWithdraw(args: LendingWithdrawArgs): Promise<LendingResult> {
+    this.ensureInitialized();
+    return blendWithdraw(this.config, this.keypair.secret(), args);
+  }
+
+  /**
+   * Repay a borrowed asset to a Blend pool.
+   */
+  async lendingRepay(args: LendingRepayArgs): Promise<LendingResult> {
+    this.ensureInitialized();
+    return blendRepay(this.config, this.keypair.secret(), args);
   }
 }

--- a/packages/stellar-agent-kit/src/index.ts
+++ b/packages/stellar-agent-kit/src/index.ts
@@ -25,10 +25,14 @@ export {
 export {
   lendingSupply,
   lendingBorrow,
+  lendingWithdraw,
+  lendingRepay,
   BLEND_POOLS,
   BLEND_POOLS_MAINNET,
   type LendingSupplyArgs,
   type LendingBorrowArgs,
+  type LendingWithdrawArgs,
+  type LendingRepayArgs,
   type LendingResult,
 } from "./lending/index.js";
 export { FXDAO_MAINNET, ALLBRIDGE_CORE_STELLAR_DOCS } from "./config/protocols.js";

--- a/packages/stellar-agent-kit/src/lending/blend.ts
+++ b/packages/stellar-agent-kit/src/lending/blend.ts
@@ -36,6 +36,18 @@ export interface LendingBorrowArgs {
   amount: string;
 }
 
+export interface LendingWithdrawArgs {
+  poolId: string;
+  assetContractId: string;
+  amount: string;
+}
+
+export interface LendingRepayArgs {
+  poolId: string;
+  assetContractId: string;
+  amount: string;
+}
+
 export interface LendingResult {
   hash: string;
   status: string;
@@ -137,6 +149,74 @@ export async function lendingBorrow(
   const sendResult = await server.sendTransaction(prepared);
   if (sendResult.errorResult) {
     throw new Error(`Blend borrow failed: ${String(sendResult.errorResult)}`);
+  }
+  return { hash: sendResult.hash, status: sendResult.status ?? "PENDING" };
+}
+
+/**
+ * Withdraw (remove) collateral from a Blend pool.
+ */
+export async function lendingWithdraw(
+  networkConfig: NetworkConfig,
+  secretKey: string,
+  args: LendingWithdrawArgs
+): Promise<LendingResult> {
+  const amountBigInt = BigInt(args.amount);
+  const requests: Request[] = [
+    {
+      request_type: RequestType.WithdrawCollateral,
+      address: args.assetContractId,
+      amount: amountBigInt,
+    },
+  ];
+  const { tx, keypair } = await buildSubmitTx(
+    networkConfig,
+    secretKey,
+    args.poolId,
+    requests
+  );
+  const server = new rpc.Server(networkConfig.sorobanRpcUrl, {
+    allowHttp: networkConfig.sorobanRpcUrl.startsWith("http:"),
+  });
+  const prepared = await server.prepareTransaction(tx);
+  prepared.sign(keypair);
+  const sendResult = await server.sendTransaction(prepared);
+  if (sendResult.errorResult) {
+    throw new Error(`Blend withdraw failed: ${String(sendResult.errorResult)}`);
+  }
+  return { hash: sendResult.hash, status: sendResult.status ?? "PENDING" };
+}
+
+/**
+ * Repay a borrowed asset to a Blend pool.
+ */
+export async function lendingRepay(
+  networkConfig: NetworkConfig,
+  secretKey: string,
+  args: LendingRepayArgs
+): Promise<LendingResult> {
+  const amountBigInt = BigInt(args.amount);
+  const requests: Request[] = [
+    {
+      request_type: RequestType.Repay,
+      address: args.assetContractId,
+      amount: amountBigInt,
+    },
+  ];
+  const { tx, keypair } = await buildSubmitTx(
+    networkConfig,
+    secretKey,
+    args.poolId,
+    requests
+  );
+  const server = new rpc.Server(networkConfig.sorobanRpcUrl, {
+    allowHttp: networkConfig.sorobanRpcUrl.startsWith("http:"),
+  });
+  const prepared = await server.prepareTransaction(tx);
+  prepared.sign(keypair);
+  const sendResult = await server.sendTransaction(prepared);
+  if (sendResult.errorResult) {
+    throw new Error(`Blend repay failed: ${String(sendResult.errorResult)}`);
   }
   return { hash: sendResult.hash, status: sendResult.status ?? "PENDING" };
 }

--- a/packages/stellar-agent-kit/src/lending/index.ts
+++ b/packages/stellar-agent-kit/src/lending/index.ts
@@ -1,13 +1,17 @@
 /**
- * Lending module – Blend Protocol (supply, borrow).
+ * Lending module – Blend Protocol (supply, borrow, withdraw, repay).
  */
 
 export {
   lendingSupply,
   lendingBorrow,
+  lendingWithdraw,
+  lendingRepay,
   BLEND_POOLS,
   BLEND_POOLS_MAINNET,
   type LendingSupplyArgs,
   type LendingBorrowArgs,
+  type LendingWithdrawArgs,
+  type LendingRepayArgs,
   type LendingResult,
 } from "./blend.js";

--- a/ui/app/api/lending/repay/route.ts
+++ b/ui/app/api/lending/repay/route.ts
@@ -1,0 +1,109 @@
+import { NextRequest, NextResponse } from "next/server"
+import {
+  TransactionBuilder,
+  Networks,
+  xdr,
+  Horizon,
+  rpc,
+} from "@stellar/stellar-sdk"
+import { PoolContractV2, RequestType, type Request } from "@blend-capital/blend-sdk"
+import { getNetworkConfig } from "stellar-agent-kit"
+import { requireActivePlan } from "@/lib/require-active-plan"
+
+/** Default active pool (FixedV2). */
+const DEFAULT_POOL_ID = "CAJJZSGMMM3PD7N33TAPHGBUGTB43OC73HVIK2L2G6BNGGGYOSSYBXBD"
+
+/** Amount in human form (e.g. "10") → smallest units (7 decimals) for Stellar assets. */
+function toSmallestUnits(amount: string): string {
+  const num = parseFloat(amount)
+  if (!Number.isFinite(num) || num < 0) {
+    throw new Error("Invalid amount")
+  }
+  const scaled = Math.round(num * 1e7).toString()
+  return scaled
+}
+
+export async function POST(request: NextRequest) {
+  const auth = requireActivePlan(request)
+  if (auth instanceof NextResponse) return auth
+  try {
+    const { publicKey, asset, amount, network = "mainnet", poolId } = await request.json()
+
+    if (!publicKey || !asset || !amount) {
+      return NextResponse.json(
+        { error: "Missing required fields: publicKey, asset, amount" },
+        { status: 400 }
+      )
+    }
+
+    // Blend Protocol is mainnet-only
+    if (network === "testnet") {
+      return NextResponse.json(
+        { error: "Blend Protocol lending is only available on mainnet. Please switch to mainnet to use lending features." },
+        { status: 400 }
+      )
+    }
+
+    const assetContractId = String(asset).trim()
+    const amountInSmallestUnit = toSmallestUnits(String(amount))
+    const amountBigInt = BigInt(amountInSmallestUnit)
+
+    if (amountBigInt <= 0n) {
+      return NextResponse.json(
+        { error: "Amount must be greater than 0" },
+        { status: 400 }
+      )
+    }
+
+    const networkConfig = getNetworkConfig(network)
+    const effectivePoolId = (typeof poolId === "string" && poolId.trim()) ? poolId.trim() : DEFAULT_POOL_ID
+    const pool = new PoolContractV2(effectivePoolId)
+
+    const requests: Request[] = [
+      {
+        request_type: RequestType.Repay,
+        address: assetContractId,
+        amount: amountBigInt,
+      },
+    ]
+
+    const submitOpXdr = pool.submit({
+      from: publicKey,
+      spender: publicKey,
+      to: publicKey,
+      requests,
+    })
+
+    const op = xdr.Operation.fromXDR(submitOpXdr, "base64")
+    const networkPassphrase = Networks.PUBLIC
+    const horizon = new Horizon.Server(networkConfig.horizonUrl)
+    const sourceAccount = await horizon.loadAccount(publicKey)
+
+    const tx = new TransactionBuilder(sourceAccount, {
+      fee: "10000",
+      networkPassphrase,
+    })
+      .addOperation(op)
+      .setTimeout(180)
+      .build()
+
+    const server = new rpc.Server(networkConfig.sorobanRpcUrl, {
+      allowHttp: networkConfig.sorobanRpcUrl.startsWith("http:"),
+    })
+    const prepared = await server.prepareTransaction(tx)
+
+    return NextResponse.json({
+      xdr: prepared.toXDR(),
+      asset: assetContractId,
+      amount: amountInSmallestUnit,
+      operation: "repay",
+    })
+  } catch (error) {
+    console.error("Repay API error:", error)
+    const message = error instanceof Error ? error.message : "Failed to build repay transaction"
+    return NextResponse.json(
+      { error: message },
+      { status: 500 }
+    )
+  }
+}

--- a/ui/app/api/lending/withdraw/route.ts
+++ b/ui/app/api/lending/withdraw/route.ts
@@ -1,0 +1,109 @@
+import { NextRequest, NextResponse } from "next/server"
+import {
+  TransactionBuilder,
+  Networks,
+  xdr,
+  Horizon,
+  rpc,
+} from "@stellar/stellar-sdk"
+import { PoolContractV2, RequestType, type Request } from "@blend-capital/blend-sdk"
+import { getNetworkConfig } from "stellar-agent-kit"
+import { requireActivePlan } from "@/lib/require-active-plan"
+
+/** Default active pool (FixedV2). */
+const DEFAULT_POOL_ID = "CAJJZSGMMM3PD7N33TAPHGBUGTB43OC73HVIK2L2G6BNGGGYOSSYBXBD"
+
+/** Amount in human form (e.g. "10") → smallest units (7 decimals) for Stellar assets. */
+function toSmallestUnits(amount: string): string {
+  const num = parseFloat(amount)
+  if (!Number.isFinite(num) || num < 0) {
+    throw new Error("Invalid amount")
+  }
+  const scaled = Math.round(num * 1e7).toString()
+  return scaled
+}
+
+export async function POST(request: NextRequest) {
+  const auth = requireActivePlan(request)
+  if (auth instanceof NextResponse) return auth
+  try {
+    const { publicKey, asset, amount, network = "mainnet", poolId } = await request.json()
+
+    if (!publicKey || !asset || !amount) {
+      return NextResponse.json(
+        { error: "Missing required fields: publicKey, asset, amount" },
+        { status: 400 }
+      )
+    }
+
+    // Blend Protocol is mainnet-only
+    if (network === "testnet") {
+      return NextResponse.json(
+        { error: "Blend Protocol lending is only available on mainnet. Please switch to mainnet to use lending features." },
+        { status: 400 }
+      )
+    }
+
+    const assetContractId = String(asset).trim()
+    const amountInSmallestUnit = toSmallestUnits(String(amount))
+    const amountBigInt = BigInt(amountInSmallestUnit)
+
+    if (amountBigInt <= 0n) {
+      return NextResponse.json(
+        { error: "Amount must be greater than 0" },
+        { status: 400 }
+      )
+    }
+
+    const networkConfig = getNetworkConfig(network)
+    const effectivePoolId = (typeof poolId === "string" && poolId.trim()) ? poolId.trim() : DEFAULT_POOL_ID
+    const pool = new PoolContractV2(effectivePoolId)
+
+    const requests: Request[] = [
+      {
+        request_type: RequestType.WithdrawCollateral,
+        address: assetContractId,
+        amount: amountBigInt,
+      },
+    ]
+
+    const submitOpXdr = pool.submit({
+      from: publicKey,
+      spender: publicKey,
+      to: publicKey,
+      requests,
+    })
+
+    const op = xdr.Operation.fromXDR(submitOpXdr, "base64")
+    const networkPassphrase = Networks.PUBLIC
+    const horizon = new Horizon.Server(networkConfig.horizonUrl)
+    const sourceAccount = await horizon.loadAccount(publicKey)
+
+    const tx = new TransactionBuilder(sourceAccount, {
+      fee: "10000",
+      networkPassphrase,
+    })
+      .addOperation(op)
+      .setTimeout(180)
+      .build()
+
+    const server = new rpc.Server(networkConfig.sorobanRpcUrl, {
+      allowHttp: networkConfig.sorobanRpcUrl.startsWith("http:"),
+    })
+    const prepared = await server.prepareTransaction(tx)
+
+    return NextResponse.json({
+      xdr: prepared.toXDR(),
+      asset: assetContractId,
+      amount: amountInSmallestUnit,
+      operation: "withdraw",
+    })
+  } catch (error) {
+    console.error("Withdraw API error:", error)
+    const message = error instanceof Error ? error.message : "Failed to build withdraw transaction"
+    return NextResponse.json(
+      { error: message },
+      { status: 500 }
+    )
+  }
+}

--- a/ui/components/blend-interface.tsx
+++ b/ui/components/blend-interface.tsx
@@ -8,7 +8,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Alert, AlertDescription } from "@/components/ui/alert"
-import { Loader2, TrendingUp, TrendingDown, Info, CheckCircle, XCircle } from "lucide-react"
+import { Loader2, TrendingUp, TrendingDown, ArrowUpFromLine, RotateCcw, Info, CheckCircle, XCircle } from "lucide-react"
 import { useAccount } from "@/hooks/use-account"
 import { useBalance } from "@/hooks/use-balance"
 import { useNetworkProfile } from "@/contexts/network-profile-context"
@@ -52,7 +52,7 @@ interface SupplyBorrowState {
 }
 
 // Helper function to parse Blend error messages
-function parseBlendError(errorMessage: string, operation: 'supply' | 'borrow' = 'supply'): string {
+function parseBlendError(errorMessage: string, operation: 'supply' | 'borrow' | 'withdraw' | 'repay' = 'supply'): string {
   if (errorMessage.includes("#1206")) {
     if (operation === 'supply') {
       return "Invalid pool status. The Blend pool may be frozen or in a restricted state—supply is not allowed right now. Check pool status at blend.capital or try again later."
@@ -96,6 +96,18 @@ export function BlendInterface() {
     error: null,
   })
   const [borrowState, setBorrowState] = useState<SupplyBorrowState>({
+    asset: BLEND_ASSETS[0],
+    amount: "",
+    isLoading: false,
+    error: null,
+  })
+  const [withdrawState, setWithdrawState] = useState<SupplyBorrowState>({
+    asset: BLEND_ASSETS[0],
+    amount: "",
+    isLoading: false,
+    error: null,
+  })
+  const [repayState, setRepayState] = useState<SupplyBorrowState>({
     asset: BLEND_ASSETS[0],
     amount: "",
     isLoading: false,
@@ -196,6 +208,142 @@ export function BlendInterface() {
       setSupplyState(prev => ({
         ...prev,
         error: parseBlendError(errorMessage, 'supply'),
+        isLoading: false,
+      }))
+    }
+  }
+
+  const handleWithdraw = async () => {
+    if (!isConnected || !publicKey || !withdrawState.asset || !withdrawState.amount) {
+      setWithdrawState(prev => ({ ...prev, error: "Please connect wallet and fill all fields" }))
+      return
+    }
+    if (hasNetworkMismatch) {
+      setShowNetworkMismatch(true)
+      return
+    }
+    setWithdrawState(prev => ({ ...prev, isLoading: true, error: null }))
+    try {
+      const response = await fetch("/api/lending/withdraw", {
+        method: "POST",
+        headers: demoApiHeaders(),
+        body: JSON.stringify({
+          publicKey,
+          asset: withdrawState.asset!.contractId,
+          amount: withdrawState.amount,
+          network: account ? normalizeNetwork(account.network) : "mainnet",
+          poolId,
+        }),
+      })
+      if (!response.ok) {
+        const error = await response.text()
+        throw new Error(error || "Failed to build withdraw transaction")
+      }
+      const { xdr } = await response.json()
+      const networkPassphrase = "Public Global Stellar Network ; September 2015"
+      const signedXdr = await signTransaction(xdr, { networkPassphrase })
+      const network = account ? normalizeNetwork(account.network) : "mainnet"
+      const submitResponse = await fetch("/api/lending/submit", {
+        method: "POST",
+        headers: demoApiHeaders(),
+        body: JSON.stringify({ signedXdr, network }),
+      })
+      if (!submitResponse.ok) {
+        const body = await submitResponse.text()
+        let message = "Failed to submit transaction"
+        try {
+          const parsed = JSON.parse(body)
+          if (typeof parsed?.error === "string") message = parsed.error
+        } catch {
+          if (body) message = body
+        }
+        throw new Error(message)
+      }
+      const { hash } = await submitResponse.json()
+      setTransactions(prev => [{
+        id: Date.now().toString(),
+        type: "withdraw",
+        asset: withdrawState.asset!.symbol,
+        amount: withdrawState.amount,
+        status: "success",
+        hash,
+        timestamp: Date.now(),
+      }, ...prev])
+      setWithdrawState(prev => ({ ...prev, amount: "", isLoading: false }))
+    } catch (error) {
+      console.error("Withdraw error:", error)
+      const errorMessage = error instanceof Error ? error.message : "Withdraw failed"
+      setWithdrawState(prev => ({
+        ...prev,
+        error: parseBlendError(errorMessage, 'withdraw'),
+        isLoading: false,
+      }))
+    }
+  }
+
+  const handleRepay = async () => {
+    if (!isConnected || !publicKey || !repayState.asset || !repayState.amount) {
+      setRepayState(prev => ({ ...prev, error: "Please connect wallet and fill all fields" }))
+      return
+    }
+    if (hasNetworkMismatch) {
+      setShowNetworkMismatch(true)
+      return
+    }
+    setRepayState(prev => ({ ...prev, isLoading: true, error: null }))
+    try {
+      const response = await fetch("/api/lending/repay", {
+        method: "POST",
+        headers: demoApiHeaders(),
+        body: JSON.stringify({
+          publicKey,
+          asset: repayState.asset!.contractId,
+          amount: repayState.amount,
+          network: account ? normalizeNetwork(account.network) : "mainnet",
+          poolId,
+        }),
+      })
+      if (!response.ok) {
+        const error = await response.text()
+        throw new Error(error || "Failed to build repay transaction")
+      }
+      const { xdr } = await response.json()
+      const networkPassphrase = "Public Global Stellar Network ; September 2015"
+      const signedXdr = await signTransaction(xdr, { networkPassphrase })
+      const network = account ? normalizeNetwork(account.network) : "mainnet"
+      const submitResponse = await fetch("/api/lending/submit", {
+        method: "POST",
+        headers: demoApiHeaders(),
+        body: JSON.stringify({ signedXdr, network }),
+      })
+      if (!submitResponse.ok) {
+        const body = await submitResponse.text()
+        let message = "Failed to submit transaction"
+        try {
+          const parsed = JSON.parse(body)
+          if (typeof parsed?.error === "string") message = parsed.error
+        } catch {
+          if (body) message = body
+        }
+        throw new Error(message)
+      }
+      const { hash } = await submitResponse.json()
+      setTransactions(prev => [{
+        id: Date.now().toString(),
+        type: "repay",
+        asset: repayState.asset!.symbol,
+        amount: repayState.amount,
+        status: "success",
+        hash,
+        timestamp: Date.now(),
+      }, ...prev])
+      setRepayState(prev => ({ ...prev, amount: "", isLoading: false }))
+    } catch (error) {
+      console.error("Repay error:", error)
+      const errorMessage = error instanceof Error ? error.message : "Repay failed"
+      setRepayState(prev => ({
+        ...prev,
+        error: parseBlendError(errorMessage, 'repay'),
         isLoading: false,
       }))
     }
@@ -423,23 +571,37 @@ export function BlendInterface() {
       )}
 
       <Tabs defaultValue="supply" className="w-full">
-        <TabsList className="grid w-full grid-cols-2 mb-6 bg-zinc-900 border border-zinc-700">
-          <TabsTrigger 
-            value="supply" 
+        <TabsList className="grid w-full grid-cols-4 mb-6 bg-zinc-900 border border-zinc-700">
+          <TabsTrigger
+            value="supply"
             className="data-[state=active]:bg-zinc-700 data-[state=active]:text-white"
           >
             <TrendingUp className="h-4 w-4 mr-2" />
             Supply
           </TabsTrigger>
-          <TabsTrigger 
-            value="borrow" 
+          <TabsTrigger
+            value="borrow"
             className={`data-[state=active]:bg-zinc-700 data-[state=active]:text-white ${
               !hasSuppliedAssets ? "opacity-60" : ""
             }`}
             title={!hasSuppliedAssets ? "Supply collateral first to enable borrowing" : ""}
           >
             <TrendingDown className="h-4 w-4 mr-2" />
-            Borrow {!hasSuppliedAssets && "(Supply First)"}
+            Borrow
+          </TabsTrigger>
+          <TabsTrigger
+            value="withdraw"
+            className="data-[state=active]:bg-zinc-700 data-[state=active]:text-white"
+          >
+            <ArrowUpFromLine className="h-4 w-4 mr-2" />
+            Withdraw
+          </TabsTrigger>
+          <TabsTrigger
+            value="repay"
+            className="data-[state=active]:bg-zinc-700 data-[state=active]:text-white"
+          >
+            <RotateCcw className="h-4 w-4 mr-2" />
+            Repay
           </TabsTrigger>
         </TabsList>
 
@@ -619,6 +781,164 @@ export function BlendInterface() {
             </CardContent>
           </Card>
         </TabsContent>
+
+        <TabsContent value="withdraw" className="space-y-4">
+          <Alert className="mb-4">
+            <Info className="h-4 w-4" />
+            <AlertDescription>
+              Withdraw your supplied collateral from the pool. Make sure your health factor stays above 1 after withdrawal.
+            </AlertDescription>
+          </Alert>
+          <Card className="bg-zinc-900/50 border-zinc-700">
+            <CardHeader>
+              <CardTitle className="text-white">Withdraw Collateral</CardTitle>
+              <CardDescription>Remove previously supplied assets from the pool</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="withdraw-asset" className="text-white">Asset</Label>
+                <Select
+                  value={withdrawState.asset?.symbol || ""}
+                  onValueChange={(value) => {
+                    const asset = BLEND_ASSETS.find(a => a.symbol === value)
+                    setWithdrawState(prev => ({ ...prev, asset: asset || null, error: null }))
+                  }}
+                >
+                  <SelectTrigger className="bg-zinc-800 border-zinc-600 text-white">
+                    <SelectValue placeholder="Select asset" />
+                  </SelectTrigger>
+                  <SelectContent className="bg-zinc-800 border-zinc-600">
+                    {BLEND_ASSETS.map((asset) => (
+                      <SelectItem key={asset.symbol} value={asset.symbol} className="text-white hover:bg-zinc-700">
+                        <div className="flex items-center gap-2">
+                          <span>{asset.symbol}</span>
+                          <span className="text-zinc-400">({asset.name})</span>
+                        </div>
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="withdraw-amount" className="text-white">Amount</Label>
+                <div className="relative">
+                  <Input
+                    id="withdraw-amount"
+                    type="number"
+                    placeholder="0.00"
+                    value={withdrawState.amount}
+                    onChange={(e) => setWithdrawState(prev => ({ ...prev, amount: e.target.value, error: null }))}
+                    className="bg-zinc-800 border-zinc-600 text-white pr-16"
+                  />
+                  {withdrawState.asset && (
+                    <div className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-zinc-400">
+                      {withdrawState.asset.symbol}
+                    </div>
+                  )}
+                </div>
+              </div>
+              {withdrawState.error && (
+                <Alert variant="destructive">
+                  <XCircle className="h-4 w-4" />
+                  <AlertDescription>{withdrawState.error}</AlertDescription>
+                </Alert>
+              )}
+              <Button
+                onClick={handleWithdraw}
+                disabled={withdrawState.isLoading || !withdrawState.asset || !withdrawState.amount}
+                className="w-full bg-[#a78bfa] hover:bg-[#9333ea] text-white"
+              >
+                {withdrawState.isLoading ? (
+                  <>
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                    Withdrawing...
+                  </>
+                ) : (
+                  "Withdraw Asset"
+                )}
+              </Button>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="repay" className="space-y-4">
+          <Alert className="mb-4">
+            <Info className="h-4 w-4" />
+            <AlertDescription>
+              Repay your outstanding loan to reduce debt and improve your health factor.
+            </AlertDescription>
+          </Alert>
+          <Card className="bg-zinc-900/50 border-zinc-700">
+            <CardHeader>
+              <CardTitle className="text-white">Repay Loan</CardTitle>
+              <CardDescription>Pay back borrowed assets to the pool</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="repay-asset" className="text-white">Asset</Label>
+                <Select
+                  value={repayState.asset?.symbol || ""}
+                  onValueChange={(value) => {
+                    const asset = BLEND_ASSETS.find(a => a.symbol === value)
+                    setRepayState(prev => ({ ...prev, asset: asset || null, error: null }))
+                  }}
+                >
+                  <SelectTrigger className="bg-zinc-800 border-zinc-600 text-white">
+                    <SelectValue placeholder="Select asset" />
+                  </SelectTrigger>
+                  <SelectContent className="bg-zinc-800 border-zinc-600">
+                    {BLEND_ASSETS.map((asset) => (
+                      <SelectItem key={asset.symbol} value={asset.symbol} className="text-white hover:bg-zinc-700">
+                        <div className="flex items-center gap-2">
+                          <span>{asset.symbol}</span>
+                          <span className="text-zinc-400">({asset.name})</span>
+                        </div>
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="repay-amount" className="text-white">Amount</Label>
+                <div className="relative">
+                  <Input
+                    id="repay-amount"
+                    type="number"
+                    placeholder="0.00"
+                    value={repayState.amount}
+                    onChange={(e) => setRepayState(prev => ({ ...prev, amount: e.target.value, error: null }))}
+                    className="bg-zinc-800 border-zinc-600 text-white pr-16"
+                  />
+                  {repayState.asset && (
+                    <div className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-zinc-400">
+                      {repayState.asset.symbol}
+                    </div>
+                  )}
+                </div>
+              </div>
+              {repayState.error && (
+                <Alert variant="destructive">
+                  <XCircle className="h-4 w-4" />
+                  <AlertDescription>{repayState.error}</AlertDescription>
+                </Alert>
+              )}
+              <Button
+                onClick={handleRepay}
+                disabled={repayState.isLoading || !repayState.asset || !repayState.amount}
+                className="w-full bg-[#a78bfa] hover:bg-[#9333ea] text-white"
+              >
+                {repayState.isLoading ? (
+                  <>
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                    Repaying...
+                  </>
+                ) : (
+                  "Repay Loan"
+                )}
+              </Button>
+            </CardContent>
+          </Card>
+        </TabsContent>
       </Tabs>
 
       {/* Transaction History */}
@@ -641,7 +961,7 @@ export function BlendInterface() {
                     )}
                     <div>
                       <p className="text-white text-sm font-medium">
-                        {tx.type === "supply" ? "Supplied" : "Borrowed"} {tx.amount} {tx.asset}
+                        {tx.type === "supply" ? "Supplied" : tx.type === "borrow" ? "Borrowed" : tx.type === "withdraw" ? "Withdrew" : "Repaid"} {tx.amount} {tx.asset}
                       </p>
                       <p className="text-zinc-400 text-xs">
                         {new Date(tx.timestamp).toLocaleString()}


### PR DESCRIPTION
## Summary

Adds two new lending functions to the Blend Protocol integration:

### New Functions
- **`lendingWithdraw(networkConfig, secretKey, args)`** — Withdraws collateral from a Blend pool using `RequestType.WithdrawCollateral`
- **`lendingRepay(networkConfig, secretKey, args)`** — Repays a borrowed asset to a Blend pool using `RequestType.Repay`

### Changes
- `packages/stellar-agent-kit/src/lending/blend.ts` — Added `lendingWithdraw` and `lendingRepay` functions with `LendingWithdrawArgs` and `LendingRepayArgs` interfaces
- `packages/stellar-agent-kit/src/lending/index.ts` — Exported new functions and types
- `packages/stellar-agent-kit/src/index.ts` — Re-exported from package root
- `packages/stellar-agent-kit/src/agent.ts` — Registered both functions as agent tools
- `packages/stellar-agent-kit/src/__tests__/blend.test.ts` — Added vitest unit tests (type checks + validation error cases)
- `ui/app/api/lending/withdraw/route.ts` — New API route for withdraw
- `ui/app/api/lending/repay/route.ts` — New API route for repay
- `ui/components/blend-interface.tsx` — Added Withdraw and Repay tabs to the UI

### Tests
All 49 tests pass (`npm run test` in `packages/stellar-agent-kit`).