### PR TITLE
fixed: slippageBps accepted but never enforced in execute_swap

### DIFF
--- a/packages/stellar-devkit-mcp/src/index.ts
+++ b/packages/stellar-devkit-mcp/src/index.ts
@@ -442,10 +442,29 @@ const res = await x402Fetch(url, undefined, {
       const client = createDexClient(config, apiKey);
 
       const quote = await client.getQuote(from, to, rawAmount);
-      const result = await client.executeSwap(secretKey, quote);
+
+      // Apply the user's requested slippage to minOut. The API returns its own
+      // default minOut; overriding it here ensures the on-chain minimum output
+      // actually reflects what the caller specified.
+      const userMinOut = String(
+        Math.floor(parseInt(quote.expectedOut, 10) * (1 - slippageBps / 10_000))
+      );
+      const adjustedQuote = {
+        ...quote,
+        minOut: userMinOut,
+        rawData: quote.rawData
+          ? {
+              ...(quote.rawData as Record<string, unknown>),
+              minOut: userMinOut,
+              minimumAmountOut: userMinOut,
+            }
+          : undefined,
+      };
+
+      const result = await client.executeSwap(secretKey, adjustedQuote);
 
       const expectedOutHuman = (parseInt(quote.expectedOut, 10) / 10 ** decimals).toFixed(6);
-      const minOutHuman      = (parseInt(quote.minOut,      10) / 10 ** decimals).toFixed(6);
+      const minOutHuman      = (parseInt(userMinOut,        10) / 10 ** decimals).toFixed(6);
 
       const text = [
         `✅ Swap executed successfully!`,


### PR DESCRIPTION

**Bug: `slippageBps` accepted but never enforced in `execute_swap`**

`execute_swap` advertises a `slippageBps` parameter ("Max slippage in basis points, default: 50 = 0.5%") and even displays it in the success message. But it was never actually used — `client.getQuote()` returns whatever `minOut` SoroSwap's API chose using its own internal default, and that raw value was passed straight to `executeSwap` and the build API unchanged.

A user passing `slippageBps: 200` (2%) would see "slippage: 2%" in the output while their trade was actually executing with the API's default ~0.5% minimum — meaning a swap with high price impact could succeed when the user expected it to fail.

**Fix:** After getting the quote, compute `userMinOut = floor(expectedOut × (1 − slippageBps / 10000))` and patch it onto the quote object — including inside `rawData` (which is what `executeSwap` forwards to the SoroSwap build API as the `minOut` / `minimumAmountOut` fields). The display value in the success message is also updated to show the enforced minimum rather than the API's original one.