### PR TITLE
fix: resolve issues #6, #9, #11 and add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build packages (ordered)
+        run: npm run build
+
+      - name: Typecheck
+        run: npm run typecheck --if-present

--- a/package.json
+++ b/package.json
@@ -13,12 +13,13 @@
     "onboarding"
   ],
   "scripts": {
-    "build": "npm run build:root && npm run build:agent-kit && npm run build:x402 && npm run build --workspaces --if-present",
+    "build": "npm run build:root && npm run build:agent-kit && npm run build:x402 && npm run build:mcp && npm run build:create-app",
     "build:root": "tsc",
     "build:agent-kit": "npm run build -w packages/stellar-agent-kit",
     "build:x402": "npm run build -w packages/x402-stellar-sdk",
     "build:create-app": "npm run build -w packages/create-stellar-devkit-app",
     "build:mcp": "npm run build -w packages/stellar-devkit-mcp",
+    "test:sdk": "npm run build:agent-kit && node scripts/test-sdk.mjs",
     "typecheck": "tsc --noEmit && npm run typecheck --workspaces --if-present",
     "lint": "npm run lint --workspaces --if-present",
     "dev:sdk-fe": "npm run dev -w sdk-fe --if-present",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "orbit",
+  "name": "stellar-agent-kit-ui",
   "version": "1.0.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary

Fixes three open issues and adds a CI workflow.

### fix(#11): UI package name inconsistency
- Renamed `ui/package.json` `name` from `"orbit"` to `"stellar-agent-kit-ui"` to match the README and public branding.

### fix(#6): Workspace build order
- Replaced the unordered `npm run build --workspaces --if-present` with explicit ordered steps in the root `build` script:
  `build:root → build:agent-kit → build:x402 → build:mcp → build:create-app`
- This ensures `stellar-agent-kit` and `x402-stellar-sdk` are always compiled before `stellar-devkit-mcp` and `create-stellar-devkit-app`, which depend on them.

### fix(#9): test-sdk.mjs fails when dist is missing
- Added a `test:sdk` npm script to root `package.json` that runs `build:agent-kit` first, then `node scripts/test-sdk.mjs`.
- Contributors can now run `npm run test:sdk` without manually building first.

### ci: GitHub Actions workflow
- Added `.github/workflows/ci.yml` that runs on push/PR to `main`.
- Steps: checkout → Node 20 setup → `npm ci` → ordered `npm run build` → `typecheck`.

## Files changed
- `.github/workflows/ci.yml` — new CI workflow
- `package.json` — fixed build order, added `test:sdk` script
- `ui/package.json` — renamed package from `orbit` to `stellar-agent-kit-ui`

Closes #6, #9, #11